### PR TITLE
Modification casse pour La Cantine

### DIFF
--- a/templates/fr/conduct.html.jinja2
+++ b/templates/fr/conduct.html.jinja2
@@ -83,7 +83,7 @@
         (co-)organisé par l’AFPy de manière directe ou indirecte à savoir :
       </p>
       <ul>
-        <li>les conférences (PyConFr, événement à la cantine et autre),</li>
+        <li>les conférences (PyConFr, événement à La Cantine et autre),</li>
         <li>les canaux IRC ou XMPP ou autre messagerie instantanée,</li>
         <li>planète AFPy,</li>
         <li>le blog,</li>


### PR DESCRIPTION
Si l'exemple fait bien référence à https://www.lacantine.org/, le nom a une majuscule pour chaque première lettre.